### PR TITLE
[Style/#37]: 실전회화 결과 화면 ui 디자인 변경

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -6,6 +6,8 @@ PODS:
   - AppAuth/ExternalUserAgent (1.7.6):
     - AppAuth/Core
   - boost (1.84.0)
+  - BVLinearGradient (2.8.3):
+    - React-Core
   - DoubleConversion (1.1.6)
   - EXConstants (17.1.6):
     - ExpoModulesCore
@@ -2117,6 +2119,7 @@ PODS:
 
 DEPENDENCIES:
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
+  - BVLinearGradient (from `../node_modules/react-native-linear-gradient`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - EXConstants (from `../node_modules/expo-constants/ios`)
   - Expo (from `../node_modules/expo`)
@@ -2218,6 +2221,8 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   boost:
     :podspec: "../node_modules/react-native/third-party-podspecs/boost.podspec"
+  BVLinearGradient:
+    :path: "../node_modules/react-native-linear-gradient"
   DoubleConversion:
     :podspec: "../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec"
   EXConstants:
@@ -2397,6 +2402,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
+  BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   EXConstants: be238322d57d084dc055dbd5d6fe6479510504ce
   Expo: 77b39f42396989cbe6fbef9f6fafc9b35186a95b

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react": "19.0.0",
         "react-native": "0.79.3",
         "react-native-gesture-handler": "^2.26.0",
+        "react-native-linear-gradient": "^2.8.3",
         "react-native-reanimated": "^3.17.4",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
@@ -12929,6 +12930,15 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.7.tgz",
       "integrity": "sha512-EH6i7E8epJGIcu7KpfXYXiV2JFIYITtq+rVS8uEb+92naMRBdxhTuS8Wn2Q7j9sqyO0B+Xbaaf9VdipIAmGW4w==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-linear-gradient": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/react-native-linear-gradient/-/react-native-linear-gradient-2.8.3.tgz",
+      "integrity": "sha512-KflAXZcEg54PXkLyflaSZQ3PJp4uC4whM7nT/Uot9m0e/qxFV3p6uor1983D1YOBJbJN7rrWdqIjq0T42jOJyA==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@tanstack/react-query": "^5.80.6",
     "eas-cli": "^16.6.1",
     "expo": "53.0.11",
+    "expo-speech": "~13.1.7",
     "expo-splash-screen": "~0.30.9",
     "expo-status-bar": "~2.2.3",
     "expo-web-browser": "~14.1.6",
@@ -26,12 +27,12 @@
     "react": "19.0.0",
     "react-native": "0.79.3",
     "react-native-gesture-handler": "^2.26.0",
+    "react-native-linear-gradient": "^2.8.3",
     "react-native-reanimated": "^3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-svg": "15.11.2",
-    "zustand": "^5.0.5",
-    "expo-speech": "~13.1.7"
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/components/Conversation/AnswerButton.tsx
+++ b/src/components/Conversation/AnswerButton.tsx
@@ -10,7 +10,10 @@ interface Props {
 
 function AnswerButton({ japanese, onPress }: Props) {
   return (
-    <PressButton extraStyles={[styles.answerButton]} onPress={onPress}>
+    <PressButton
+      extraStyles={[styles.answerButton, { marginLeft: -24 }]}
+      onPress={onPress}
+    >
       <Tts text={japanese} />
       <View style={styles.textWrapper}>
         <Text style={styles.answerText}>{japanese}</Text>

--- a/src/components/Conversation/ChoiceContent.tsx
+++ b/src/components/Conversation/ChoiceContent.tsx
@@ -34,7 +34,12 @@ function ChoiceContent({ npcDialogue, userChoice, choiceId, onPress }: Props) {
           </View>
         </View>
       </View>
-      <View style={styles.answerWrapper}>
+      <View
+        style={[
+          styles.answerWrapper,
+          { position: 'absolute', bottom: '13%', left: 0, right: 0 },
+        ]}
+      >
         <Text style={styles.answerGuide}>
           질문에 원하는 대답을 선택해주세요
         </Text>

--- a/src/components/Conversation/ResponseContent.tsx
+++ b/src/components/Conversation/ResponseContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Image, Text } from 'react-native';
+import { View, Image, Text, ScrollView } from 'react-native';
 import Tts from '@/components/commons/Tts';
 import { styles } from '@/styles/Conversation/Conversation.style';
 import {
@@ -31,38 +31,54 @@ function ResponseContent({
 
   return (
     <>
-      <View style={styles.dialogueWrapper}>
-        <Image source={imageSource} style={styles.image} />
-        <View>
-          <View style={styles.npcTriangle} />
-          <View style={styles.npcAnswer}>
-            <Tts color="#FF9A9A" text={npcQuestion} />
-            <View style={styles.textWrapper}>
-              <Text style={styles.npcAnswerText}>{npcQuestion}</Text>
-              <Text style={styles.koreanText}>{npcQuestionKorean}</Text>
+      <Image source={imageSource} style={styles.image} />
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.dialogueWrapper}>
+          <View style={{ marginLeft: 48 }}>
+            <View style={styles.npcTriangle} />
+            <View style={[styles.npcAnswer, { width: '100%' }]}>
+              <Tts color="#FF9A9A" text={npcQuestion} />
+              <View style={styles.textWrapper}>
+                <Text style={styles.npcAnswerText}>{npcQuestion}</Text>
+                <Text style={styles.koreanText}>{npcQuestionKorean}</Text>
+              </View>
+            </View>
+          </View>
+          <View style={[styles.answerWrapper, { width: '90%' }]}>
+            <View style={[styles.answerButton]}>
+              <Tts text={userDialogue} />
+              <View style={styles.textWrapper}>
+                <Text style={styles.answerText}>{userDialogue}</Text>
+                <Text style={styles.koreanText}>{userKorean}</Text>
+              </View>
+            </View>
+          </View>
+          <View style={{ marginLeft: 48 }}>
+            <View style={styles.npcTriangle} />
+            <View style={[styles.npcAnswer, { width: '100%' }]}>
+              <Tts color="#FF9A9A" text={npcDialogue} />
+              <View style={styles.textWrapper}>
+                <Text style={styles.npcAnswerText}>{npcDialogue}</Text>
+                <Text style={styles.koreanText}>{npcKorean}</Text>
+              </View>
+            </View>
+          </View>
+          <View style={{ marginLeft: 48 }}>
+            <View style={styles.npcTriangle} />
+            <View style={[styles.npcAnswer, { width: '100%' }]}>
+              <Tts color="#FF9A9A" text={npcDialogue} />
+              <View style={styles.textWrapper}>
+                <Text style={styles.npcAnswerText}>{npcDialogue}</Text>
+                <Text style={styles.koreanText}>{npcKorean}</Text>
+              </View>
             </View>
           </View>
         </View>
-        <View style={styles.answerWrapper}>
-          <View style={[styles.answerButton]}>
-            <Tts text={userDialogue} />
-            <View style={styles.textWrapper}>
-              <Text style={styles.answerText}>{userDialogue}</Text>
-              <Text style={styles.koreanText}>{userKorean}</Text>
-            </View>
-          </View>
-        </View>
-        <View>
-          <View style={styles.npcTriangle} />
-          <View style={styles.npcAnswer}>
-            <Tts color="#FF9A9A" text={npcDialogue} />
-            <View style={styles.textWrapper}>
-              <Text style={styles.npcAnswerText}>{npcDialogue}</Text>
-              <Text style={styles.koreanText}>{npcKorean}</Text>
-            </View>
-          </View>
-        </View>
-      </View>
+      </ScrollView>
     </>
   );
 }

--- a/src/components/Conversation/ResponseContent.tsx
+++ b/src/components/Conversation/ResponseContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { View, Image, Text, ScrollView } from 'react-native';
 import Tts from '@/components/commons/Tts';
 import { styles } from '@/styles/Conversation/Conversation.style';
@@ -27,8 +27,23 @@ function ResponseContent({
   userKorean,
   responseId,
 }: Props) {
-  // 매핑 객체에서 이미지 가져오기
+  const [isVisible, setIsVisible] = useState(false);
   const imageSource = conversationImages[responseId];
+
+  const handleScroll = (event: any) => {
+    const { layoutMeasurement, contentOffset, contentSize } = event.nativeEvent;
+    const paddingToBottom = 20;
+
+    if (
+      layoutMeasurement.height + contentOffset.y >=
+      contentSize.height - paddingToBottom
+    ) {
+      setIsVisible(true);
+      return;
+    }
+
+    setIsVisible(false);
+  };
 
   return (
     <>
@@ -37,6 +52,8 @@ function ResponseContent({
         style={styles.scrollView}
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
       >
         <View style={styles.dialogueWrapper}>
           <View style={{ marginLeft: 48 }}>
@@ -79,13 +96,17 @@ function ResponseContent({
             </View>
           </View>
         </View>
+        {/* 여기 위치한 요소가 화면에 보일경우 */}
       </ScrollView>
-      <LinearGradient
-        colors={['rgba(255, 255, 255, 0.00)', '#FFF']}
-        start={{ x: 0, y: 0 }}
-        end={{ x: 0, y: 1 }}
-        style={styles.scrollable}
-      ></LinearGradient>
+
+      {!isVisible && (
+        <LinearGradient
+          colors={['rgba(255, 255, 255, 0.00)', '#FFF']}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 0, y: 1 }}
+          style={styles.scrollable}
+        ></LinearGradient>
+      )}
     </>
   );
 }

--- a/src/components/Conversation/ResponseContent.tsx
+++ b/src/components/Conversation/ResponseContent.tsx
@@ -6,6 +6,7 @@ import {
   conversationImages,
   ConversationImageKey,
 } from '../../../assets/images/public/conversation';
+import LinearGradient from 'react-native-linear-gradient';
 
 interface Props {
   npcQuestion: string;
@@ -79,6 +80,12 @@ function ResponseContent({
           </View>
         </View>
       </ScrollView>
+      <LinearGradient
+        colors={['rgba(255, 255, 255, 0.00)', '#FFF']}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 0, y: 1 }}
+        style={styles.scrollable}
+      ></LinearGradient>
     </>
   );
 }

--- a/src/components/Conversation/ResponseContent.tsx
+++ b/src/components/Conversation/ResponseContent.tsx
@@ -8,6 +8,8 @@ import {
 } from '../../../assets/images/public/conversation';
 
 interface Props {
+  npcQuestion: string;
+  npcQuestionKorean: string;
   npcDialogue: string;
   npcKorean: string;
   userDialogue: string;
@@ -16,6 +18,8 @@ interface Props {
 }
 
 function ResponseContent({
+  npcQuestion,
+  npcQuestionKorean,
   npcDialogue,
   npcKorean,
   userDialogue,
@@ -27,8 +31,27 @@ function ResponseContent({
 
   return (
     <>
-      <View>
+      <View style={styles.dialogueWrapper}>
         <Image source={imageSource} style={styles.image} />
+        <View>
+          <View style={styles.npcTriangle} />
+          <View style={styles.npcAnswer}>
+            <Tts color="#FF9A9A" text={npcQuestion} />
+            <View style={styles.textWrapper}>
+              <Text style={styles.npcAnswerText}>{npcQuestion}</Text>
+              <Text style={styles.koreanText}>{npcQuestionKorean}</Text>
+            </View>
+          </View>
+        </View>
+        <View style={styles.answerWrapper}>
+          <View style={[styles.answerButton]}>
+            <Tts text={userDialogue} />
+            <View style={styles.textWrapper}>
+              <Text style={styles.answerText}>{userDialogue}</Text>
+              <Text style={styles.koreanText}>{userKorean}</Text>
+            </View>
+          </View>
+        </View>
         <View>
           <View style={styles.npcTriangle} />
           <View style={styles.npcAnswer}>
@@ -37,15 +60,6 @@ function ResponseContent({
               <Text style={styles.npcAnswerText}>{npcDialogue}</Text>
               <Text style={styles.koreanText}>{npcKorean}</Text>
             </View>
-          </View>
-        </View>
-      </View>
-      <View style={[styles.answerWrapper, { bottom: '20%' }]}>
-        <View style={[styles.answerButton]}>
-          <Tts text={userDialogue} />
-          <View style={styles.textWrapper}>
-            <Text style={styles.answerText}>{userDialogue}</Text>
-            <Text style={styles.koreanText}>{userKorean}</Text>
           </View>
         </View>
       </View>

--- a/src/data/conversation.ts
+++ b/src/data/conversation.ts
@@ -25,14 +25,13 @@ export const conversationData: Conversation[] = [
     theme: '카페',
     situationImage: 'assets/images/public/cafe/cafe_situation.webp',
     question: {
-      japanese:
-        'いらっしゃいませ。ご注文はお決まりですか？ いらっしゃいませ。ご注文はお決まりですか？',
+      japanese: 'いらっしゃいませ。ご注文はお決まりですか？',
       korean: '어서 오세요. 주문은 정하셨나요?',
     },
     userChoice: [
       {
         responseId: 'cafe_situation_response_1',
-        japanese: 'コーヒーとケーキをください。 コーヒーとケーキをください。',
+        japanese: 'コーヒーとケーキをください。',
         korean: '커피와 케이크 주세요.',
       },
       {
@@ -46,8 +45,7 @@ export const conversationData: Conversation[] = [
         responseId: 'cafe_situation_response_1',
         responseImage:
           'assets/images/public/cafe/cafe_situation_response_1.webp',
-        japanese:
-          'かしこまりました。お席でお待ちください。 かしこまりました。お席でお待ちください。',
+        japanese: 'かしこまりました。お席でお待ちください。',
         korean: '알겠습니다. 자리에서 기다려 주세요.',
       },
       {

--- a/src/data/conversation.ts
+++ b/src/data/conversation.ts
@@ -25,13 +25,14 @@ export const conversationData: Conversation[] = [
     theme: '카페',
     situationImage: 'assets/images/public/cafe/cafe_situation.webp',
     question: {
-      japanese: 'いらっしゃいませ。ご注文はお決まりですか？',
+      japanese:
+        'いらっしゃいませ。ご注文はお決まりですか？ いらっしゃいませ。ご注文はお決まりですか？',
       korean: '어서 오세요. 주문은 정하셨나요?',
     },
     userChoice: [
       {
         responseId: 'cafe_situation_response_1',
-        japanese: 'コーヒーとケーキをください。',
+        japanese: 'コーヒーとケーキをください。 コーヒーとケーキをください。',
         korean: '커피와 케이크 주세요.',
       },
       {
@@ -45,7 +46,8 @@ export const conversationData: Conversation[] = [
         responseId: 'cafe_situation_response_1',
         responseImage:
           'assets/images/public/cafe/cafe_situation_response_1.webp',
-        japanese: 'かしこまりました。お席でお待ちください。',
+        japanese:
+          'かしこまりました。お席でお待ちください。 かしこまりました。お席でお待ちください。',
         korean: '알겠습니다. 자리에서 기다려 주세요.',
       },
       {

--- a/src/screens/Conversation.tsx
+++ b/src/screens/Conversation.tsx
@@ -69,17 +69,6 @@ function Conversation() {
     }, 250);
   };
 
-  // const convertJapanese = (japanese: string) => {
-  //   if (!japanese.includes('。')) return japanese;
-
-  //   return japanese
-  //     .split('。')
-  //     .filter((text) => text.trim())
-  //     .map((text, index) => {
-  //       return index === 0 ? `${text}。` : `${text}。`;
-  //     });
-  // };
-
   return (
     <SafeAreaScreen>
       <View style={styles.container}>
@@ -101,6 +90,8 @@ function Conversation() {
         <Animated.View style={[styles.realContainer, animatedStyle]}>
           {isSelected ? (
             <ResponseContent
+              npcQuestion={conversation?.question.japanese}
+              npcQuestionKorean={conversation?.question.korean}
               npcDialogue={conversation?.response[selectedAnswer].japanese}
               npcKorean={conversation?.response[selectedAnswer].korean}
               userDialogue={conversation?.userChoice[selectedAnswer].japanese}

--- a/src/styles/Conversation/Conversation.style.ts
+++ b/src/styles/Conversation/Conversation.style.ts
@@ -18,6 +18,11 @@ export const styles = StyleSheet.create({
     borderTopLeftRadius: 15,
     borderTopRightRadius: 15,
   },
+  dialogueWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 28,
+  },
   image: {
     width: 294,
     height: 240,
@@ -26,12 +31,11 @@ export const styles = StyleSheet.create({
     width: 0,
     height: 0,
     marginLeft: 35,
+    marginTop: -20,
 
-    borderTopWidth: 20,
     borderBottomWidth: 20,
     borderLeftWidth: 15,
     borderRightWidth: 15,
-    borderTopColor: 'transparent',
     borderBottomColor: '#FFDADA',
     borderLeftColor: 'transparent',
     borderRightColor: 'transparent',
@@ -71,11 +75,6 @@ export const styles = StyleSheet.create({
     flexShrink: 1,
   },
   answerWrapper: {
-    position: 'absolute',
-    bottom: '13%',
-    left: 0,
-    right: 0,
-
     flexDirection: 'column',
     gap: 18,
   },

--- a/src/styles/Conversation/Conversation.style.ts
+++ b/src/styles/Conversation/Conversation.style.ts
@@ -1,4 +1,6 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Dimensions } from 'react-native';
+
+const { width } = Dimensions.get('window');
 
 export const styles = StyleSheet.create({
   container: {
@@ -113,5 +115,14 @@ export const styles = StyleSheet.create({
     color: '#313239',
     fontSize: 20,
     fontWeight: 500,
+  },
+  scrollable: {
+    position: 'absolute',
+    bottom: 50,
+    left: -24,
+    right: 0,
+    zIndex: 1000,
+    width: width + 24,
+    height: 60,
   },
 });

--- a/src/styles/Conversation/Conversation.style.ts
+++ b/src/styles/Conversation/Conversation.style.ts
@@ -18,6 +18,16 @@ export const styles = StyleSheet.create({
     borderTopLeftRadius: 15,
     borderTopRightRadius: 15,
   },
+  scrollView: {
+    width: '130%',
+    marginLeft: -48,
+    flex: 1,
+  },
+  scrollContent: {
+    paddingTop: 20,
+    paddingBottom: 100,
+  },
+
   dialogueWrapper: {
     display: 'flex',
     flexDirection: 'column',
@@ -26,6 +36,7 @@ export const styles = StyleSheet.create({
   image: {
     width: 294,
     height: 240,
+    marginBottom: 28,
   },
   npcTriangle: {
     width: 0,
@@ -90,7 +101,6 @@ export const styles = StyleSheet.create({
     paddingVertical: 18,
     paddingLeft: 24,
     paddingRight: 24,
-    marginLeft: -24,
 
     flexDirection: 'row',
     gap: 15,


### PR DESCRIPTION
## 📍 작업 내용

> 실전회화 결과 화면 ui 디자인을 변경했습니다.

- [x] npc -> user -> npc 순서의 말풍선 배치
- [x] Scrollable 컴포넌트 추가
- [x] 스크롤 바닥인 경우 Scrollable 분기 렌더링

<br/>

## 📍 구현 결과 (선택)


<br/>

## 📍 기타 사항

<br/>
